### PR TITLE
add backend start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install setup_husky clean lint gas format format_check format_contract test	test_contract before_commit build_frontend start build_backend	build_contract export_pdf help
+.PHONY: install setup_husky dev	clean lint gas format format_check format_contract test	test_contract before_commit build_frontend start build_backend	build_contract export_pdf help
 
 # -------------------------------
 # Help
@@ -9,6 +9,7 @@ help:              # Show this help message
 	@echo "Targets:"
 	@echo "  install         Install npm packages"
 	@echo "  setup_husky     Setup Husky for git hooks"
+	@echo "  dev             Start the frontend in development mode"
 	@echo "  clean           Clean the project"
 	@echo "  lint            Run linter"
 	@echo "  format          Format code"
@@ -34,6 +35,12 @@ install:           # Install npm packages
 
 setup_husky:       # Setup Husky for git hooks
 	npm run husky
+
+# -------------------------------
+# Development
+# -------------------------------
+dev:
+	npm run dev
 
 # -------------------------------
 # Code Quality and Formatting

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,9 @@
     "format:check": "prettier --check '**/*.ts' --ignore-path .gitignore",
     "lint": "eslint '**/*.{ts,yaml,yml}'",
     "test": "jest --coverage  --verbose --silent --forceExit",
-    "test:ci": "jest --coverage --verbose --silent --forceExit"
+    "test:ci": "jest --coverage --verbose --silent --forceExit",
+    "dev": "ts-node src/server.ts",
+    "start": "node dist/server.js"
   },
   "keywords": [],
   "description": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/supertest": "^6.0.2",
+        "concurrently": "^8.2.0",
         "esbuild": "0.24.2",
         "eslint": "^9.17.0",
         "eslint-plugin-yml": "^1.16.0",
@@ -5874,6 +5875,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -6172,6 +6217,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -13952,6 +14014,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -14363,6 +14435,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -14658,6 +14743,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
@@ -16916,6 +17007,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/trough": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "npm run --workspaces lint --fix && eslint '.github/**/*.{ts,js,yaml,yml}' --fix",
     "husky": "husky",
     "start": "concurrently \"npm start --prefix frontend\" \"npm start --prefix backend\"",
+    "dev": "concurrently \"npm run dev --prefix frontend\" \"npm run dev --prefix backend\"",
     "install-all": "npm install && npm install --prefix frontend"
   },
   "keywords": [],
@@ -51,6 +52,7 @@
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "textlint-rule-spellcheck-tech-word": "^5.0.0",
-    "ts-jest": "^29.2.5"
+    "ts-jest": "^29.2.5",
+    "concurrently": "^8.2.0"
   }
 }


### PR DESCRIPTION
This pull request introduces a new development mode for the project, modifies the `Makefile` to include the new `dev` target, and updates the `package.json` files to support the new development workflow. The most important changes are summarized below:

### Makefile updates:

* Added a new `dev` target to start the frontend in development mode and updated the `.PHONY` list to include this new target. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R39-R44)

### `package.json` updates:

* Added a `dev` script to the root `package.json` to concurrently run the frontend and backend in development mode.
* Added a `dev` script to `backend/package.json` to start the backend server using `ts-node` for development.
* Added `concurrently` as a dependency in the root `package.json` to facilitate running multiple commands concurrently.