### PR TITLE
add restake service

### DIFF
--- a/backend/src/routes/restake.ts
+++ b/backend/src/routes/restake.ts
@@ -1,0 +1,27 @@
+// backend/src/routes/restake.ts
+import { Router, Request, Response } from "express";
+import { fetchRestakeBalance } from "../services/restakeService.js";
+
+const router = Router();
+
+/**
+ * GET /api/restake-balance?user=<ウォレットアドレス>
+ * ユーザーアドレスをクエリパラメータ "user" で受け取り、リステーキング残高を返す
+ */
+router.get("/restake-balance", async (req: Request, res: Response) => {
+  const userAddress = req.query.user as string;
+  if (!userAddress) {
+    return res
+      .status(400)
+      .json({ error: "ユーザーアドレスを指定してください" });
+  }
+  try {
+    const balance = await fetchRestakeBalance(userAddress);
+    res.json({ balance });
+  } catch (error) {
+    console.error("Error in /restake-balance route:", error);
+    res.status(500).json({ error: "リステーキング残高の取得に失敗しました" });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,9 @@ import { createTelegramBot } from "./services/telegramService.js";
 import { aiService } from "./services/aiService.js";
 import { autonomeService } from "./services/autonomeService.js";
 
+// 新たに追加するルート
+import restakeRoutes from "./routes/restake.js";
+
 // 環境変数を読み込む
 dotenv.config();
 
@@ -105,6 +108,9 @@ app.get("/health", (req, res) => {
     },
   });
 });
+
+// 追加するリステーキング残高取得のルート
+app.use("/api", restakeRoutes);
 
 // ----------------------
 // エラーハンドリングミドルウェア

--- a/backend/src/services/restakeService.ts
+++ b/backend/src/services/restakeService.ts
@@ -1,0 +1,41 @@
+// backend/src/services/restakeService.ts
+import { JsonRpcProvider, Contract, formatEther } from "ethers";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const ETH_RPC_URL: string = process.env.ETH_RPC_URL!;
+const RESTAKE_CONTRACT_ADDRESS: string = process.env.RESTAKE_CONTRACT_ADDRESS!;
+
+// JSON RPC プロバイダーの初期化
+const provider = new JsonRpcProvider(ETH_RPC_URL);
+
+// リステーキング情報取得用の ABI（必要な関数のみ記述）
+const restakeABI: string[] = [
+  "function getRestakeBalance(address user) external view returns (uint256)",
+];
+
+// スマートコントラクトインスタンスの作成
+const restakeContract = new Contract(
+  RESTAKE_CONTRACT_ADDRESS,
+  restakeABI,
+  provider,
+);
+
+/**
+ * 指定したユーザーアドレスのリステーキング残高を取得する関数
+ * @param userAddress ユーザーのウォレットアドレス
+ * @returns 残高（Ether 単位の文字列）
+ */
+export async function fetchRestakeBalance(
+  userAddress: string,
+): Promise<string> {
+  try {
+    const balance: bigint =
+      await restakeContract.getRestakeBalance(userAddress);
+    return formatEther(balance);
+  } catch (error) {
+    console.error("Error fetching restake balance:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to fetch the restaking balance for a user based on their wallet address. The changes include adding a new route, integrating it into the server, and implementing the service to interact with the blockchain.

### New Feature: Fetch Restaking Balance

* Added a new route to handle fetching restaking balance (`backend/src/routes/restake.ts`).
* Integrated the new route into the server setup (`backend/src/server.ts`). [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR12-R14) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR112-R114)
* Implemented the `fetchRestakeBalance` function to interact with the blockchain and retrieve the balance (`backend/src/services/restakeService.ts`).