### PR TITLE
add brieging

### DIFF
--- a/backend/src/routes/aiBriefing.ts
+++ b/backend/src/routes/aiBriefing.ts
@@ -1,0 +1,34 @@
+// backend/src/routes/aiBriefing.ts
+import { Router, Request, Response } from "express";
+import { aiService } from "../services/aiService.js";
+import { UserContext } from "../types/ai.js"; // 追加：UserContext 型のインポート
+
+const router = Router();
+
+/**
+ * GET /api/ai/briefing?address=<ウォレットアドレス>
+ * クエリパラメータ "address" をもとに、AIブリーフィングを生成して返す
+ */
+router.get("/ai/briefing", async (req: Request, res: Response) => {
+  const address = req.query.address as string;
+  if (!address) {
+    return res.status(400).json({ error: "ウォレットアドレスが必要です" });
+  }
+
+  try {
+    // UserContext 型を明示的に指定して作成する
+    const userContext: UserContext = {
+      wallet_address: address,
+      risk_preference: "moderate", // "moderate" はリテラル型として扱われる
+      preferred_assets: ["ETH"],
+      activity_history: [],
+    };
+    const briefing = await aiService.getDailyBriefing(address, userContext);
+    res.json(briefing);
+  } catch (error) {
+    console.error("Error generating daily briefing:", error);
+    res.status(500).json({ error: "日次ブリーフィングの生成に失敗しました" });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -11,6 +11,7 @@ import { autonomeService } from "./services/autonomeService.js";
 
 // 新たに追加するルート
 import restakeRoutes from "./routes/restake.js";
+import aiBriefingRoutes from "./routes/aiBriefing.js";
 
 // 環境変数を読み込む
 dotenv.config();
@@ -111,7 +112,7 @@ app.get("/health", (req, res) => {
 
 // 追加するリステーキング残高取得のルート
 app.use("/api", restakeRoutes);
-
+app.use("/api", aiBriefingRoutes);
 // ----------------------
 // エラーハンドリングミドルウェア
 // ----------------------


### PR DESCRIPTION
This pull request introduces a new route for generating AI briefings based on wallet addresses. The changes involve creating a new route handler, importing necessary modules, and integrating the route into the server configuration.

Key changes include:

### New Route Implementation:

* [`backend/src/routes/aiBriefing.ts`](diffhunk://#diff-e16b7939daba637f41234091b4e8952cb69cce792caae123ecf2606aa37a05d1R1-R34): Added a new route handler for `/api/ai/briefing` that generates and returns an AI briefing based on the provided wallet address. This includes importing necessary modules (`Router`, `Request`, `Response`, `aiService`, and `UserContext`), defining the route, and handling potential errors.

### Server Configuration:

* [`backend/src/server.ts`](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR14): Imported the new `aiBriefingRoutes` and added it to the server's middleware to handle requests to `/api/ai/briefing`. [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR14) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaL114-R115)