### PR TITLE
add demo script

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,21 @@
+Here’s a concise script for a **1–2 minute** demo:
+
+---
+
+**1. Intro & Login**
+- “Welcome to CryptoDailyBrief. First, I open the login screen. I click ‘Connect Wallet’.”
+
+**2. Dashboard Overview**
+- “Now we see the dashboard. It shows my wallet balances, YouTube videos, and contract data.”
+
+**3. ERC1155 Token Check**
+- “Here’s the smart contract we deployed on Base Sepolia. We can mint an ERC1155 token and see it in my balance.”
+
+**4. Send ETH via Chat**
+- “I’ll type ‘Send 0.001 ETH to 0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950.’ The chat processes this and creates a transaction.”
+
+**5. Confirm on Block Explorer**
+- “The transaction goes through, and I can click the link to Sepolia BaseScan. We see the address’s balance has increased.”
+
+**6. Wrap-Up**
+- “That’s it! We have a simple chat-based interface that combines on-chain data, videos, and easy token transfers—all in one place.”


### PR DESCRIPTION
This pull request introduces a new concise script for a 1-2 minute demo in the `DEMO.md` file. The script outlines a step-by-step guide for demonstrating various features of the CryptoDailyBrief application.

Key changes include:

* [`DEMO.md`](diffhunk://#diff-16a76d9d5eb64ff39498269308ec62f0ee72db784cbc61a91796cffddc5c9ac5R1-R21): Added a detailed demo script that includes sections for Intro & Login, Dashboard Overview, ERC1155 Token Check, Sending ETH via Chat, Confirming on Block Explorer, and Wrap-Up.